### PR TITLE
Makes the initial import a bit faster and improve page load time while it's importing

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 # Listen on all interfaces (by default it only listens on 127.0.0.1 for local use)
 BIND_INTERFACE=0.0.0.0
-DATABASE_URL=sqlite://puzzles.sqlite
+DATABASE_URL=sqlite://puzzles2.sqlite
 BIND_PORT=3030
 SRS_DEFAULT_EASE=2.5
 SRS_MINIMUM_EASE=1.3

--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 # Listen on all interfaces (by default it only listens on 127.0.0.1 for local use)
 BIND_INTERFACE=0.0.0.0
-DATABASE_URL=sqlite://puzzles2.sqlite
+DATABASE_URL=sqlite://puzzles.sqlite
 BIND_PORT=3030
 SRS_DEFAULT_EASE=2.5
 SRS_MINIMUM_EASE=1.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,17 @@ Removed:
   have a SQLITE_DB_NAME set but not a DATABASE_URL, for compatibility DATABASE_URL will be set
   to "sqlite://{SQLITE_DB_NAME}". See CONFIG.md for more details.
 
-Fixed:
+Changed:
 * Puzzles on the 'next puzzle' page will never be ones you've seen before anymore.
+* Changes the .sqlite database to use WAL journaling (write-ahead-logging) so that multiple readers
+  can use the database while something is writing to it. Overall the application should be a little
+  faster.
+* Tweaks the initial puzzle import to be a bit faster, and not lock the database as much. This is
+  especially useful in docker, where the initial import was quite slow for me previously, and the
+  web app was very slow to load while it was importing. The database import is now a lot faster,
+  and page loads are generally instant while it is in progress. API calls that need to write (such
+  as reviewing and skipping puzzles) might still need a couple of seconds while puzzles are being
+  written to a database but it's much faster overall.
 
 [1.7.0] - 2023-10-19
 

--- a/src/api/tactics.rs
+++ b/src/api/tactics.rs
@@ -71,7 +71,7 @@ fn serialize_card<S: serde::Serializer>(card: &Option<Card>, serializer: S) -> R
 
 /// POST /api/tactics/review.
 pub async fn review(
-    State(state): State<AppState>,
+    State(mut state): State<AppState>,
     Json(request): Json<ReviewRequest>,
 ) -> ApiResult<()>
 {
@@ -160,7 +160,7 @@ pub async fn puzzle_by_id(
 
 /// GET /api/tactics/random/:min_rating/:max_rating.
 pub async fn random_puzzle(
-    State(state): State<AppState>,
+    State(mut state): State<AppState>,
     Path((min_rating, max_rating)): Path<(i64, i64)>,
 ) -> ApiResult<Json<CardResponse>>
 {
@@ -206,7 +206,7 @@ pub async fn random_puzzle(
 }
 
 pub async fn skip_next(
-    State(state): State<AppState>,
+    State(mut state): State<AppState>,
     Json(request): Json<SkipRequest>,
 ) -> ApiResult<()>
 {

--- a/src/api/user.rs
+++ b/src/api/user.rs
@@ -10,7 +10,7 @@ use crate::util;
 /// Reset the user's rating to the specified value.
 /// TODO: add this into the settings page.
 pub async fn reset_rating(
-    State(state): State<AppState>,
+    State(mut state): State<AppState>,
     Path(new_rating): Path<i64>,
 ) -> Result<ApiResponse, ApiError>
 {

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,10 +4,8 @@ use std::env::{self, VarError};
 use std::error::Error;
 use std::net::{IpAddr, Ipv4Addr};
 use std::str::FromStr;
-use std::sync::Arc;
 
 use chrono::{NaiveTime, DateTime, Local, Duration};
-use tokio::sync::Mutex;
 use url::Url;
 
 use crate::db::PuzzleDatabase;
@@ -138,7 +136,7 @@ pub struct AppState {
 }
 
 impl AppState {
-    pub fn new(app_config: AppConfig, db: Arc<Mutex<PuzzleDatabase>>) -> AppState {
+    pub fn new(app_config: AppConfig, db: PuzzleDatabase) -> AppState {
         Self {
             user_service: UserService::new(app_config.clone(), db.clone()),
             tactics_service: TacticsService::new(app_config.clone(), db.clone()),

--- a/src/app/backup.rs
+++ b/src/app/backup.rs
@@ -1,6 +1,4 @@
-use tokio::sync::Mutex;
 use std::path::Path;
-use std::sync::Arc;
 use std::error::Error;
 
 use crate::app::AppConfig;
@@ -8,7 +6,7 @@ use crate::db::PuzzleDatabase;
 use crate::time::{LocalTimeProvider, TimeProvider};
 
 /// Run the backup if a daily backup hasn't been created yet today.
-pub async fn run_backup(app_config: AppConfig, db: Arc<Mutex<PuzzleDatabase>>)
+pub async fn run_backup(app_config: AppConfig, db: PuzzleDatabase)
     -> Result<(), Box<dyn Error>>
 {
     type TP = LocalTimeProvider;
@@ -18,7 +16,6 @@ pub async fn run_backup(app_config: AppConfig, db: Arc<Mutex<PuzzleDatabase>>)
         return Ok(());
     }
 
-    let db = db.lock().await;
     let mut app_data = db.get_app_data("").await?
         .ok_or_else(|| "Failed to get app_data when trying to run backup")?;
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -70,6 +70,9 @@ impl PuzzleDatabase {
         log::info!("Running database migrations...");
         sqlx::migrate!().run(&pool).await?;
 
+        // Enable write-ahead-logging (single writer multiple readers).
+        sqlx::query("PRAGMA journal_mode=WAL").execute(&pool).await?;
+
         Ok(Self {
             pool,
             srs_config,

--- a/src/db.rs
+++ b/src/db.rs
@@ -70,8 +70,11 @@ impl PuzzleDatabase {
         log::info!("Running database migrations...");
         sqlx::migrate!().run(&pool).await?;
 
-        // Enable write-ahead-logging (single writer multiple readers).
+        // Enable write-ahead-logging (single writer multiple readers), and set the busy timeout to
+        // 30 seconds so that requests don't fail just because something is already trying to write
+        // to the database;
         sqlx::query("PRAGMA journal_mode=WAL").execute(&pool).await?;
+        sqlx::query("PRAGMA busy_timeout=30000").execute(&pool).await?;
 
         Ok(Self {
             pool,

--- a/src/db.rs
+++ b/src/db.rs
@@ -18,6 +18,7 @@ use url::Url;
 use crate::srs::SrsConfig;
 
 /// The puzzle database interface type.
+#[derive(Clone)]
 pub struct PuzzleDatabase {
     pool: SqlitePool,
     srs_config: SrsConfig,

--- a/src/db/puzzle.rs
+++ b/src/db/puzzle.rs
@@ -1,5 +1,4 @@
 use futures::TryStreamExt;
-use sqlx::Acquire;
 use sqlx::{Row, Sqlite, QueryBuilder, sqlite::SqliteRow};
 
 use crate::db::{PuzzleDatabase, DbResult};

--- a/src/db/puzzle.rs
+++ b/src/db/puzzle.rs
@@ -79,9 +79,10 @@ impl PuzzleDatabase {
 
     /// Add a batch of puzzles to the database.
     pub async fn add_puzzles(&mut self, puzzles: &Vec<Puzzle>) -> DbResult<()> {
-        const BATCH_SIZE: usize = 100;
+        const BATCH_SIZE: usize = 500;
 
-        let mut conn = self.pool.acquire().await?;
+        //let mut conn = self.pool.acquire().await?;
+        let mut conn = self.pool.begin().await?;
 
         sqlx::query("
             CREATE TEMPORARY TABLE IF NOT EXISTS lichess_puzzles (
@@ -135,6 +136,8 @@ impl PuzzleDatabase {
 
             DELETE FROM lichess_puzzles;
         ").execute(&mut *conn).await?;
+
+        conn.commit().await?;
 
         Ok(())
     }

--- a/src/db/puzzle.rs
+++ b/src/db/puzzle.rs
@@ -81,7 +81,6 @@ impl PuzzleDatabase {
     pub async fn add_puzzles(&mut self, puzzles: &Vec<Puzzle>) -> DbResult<()> {
         const BATCH_SIZE: usize = 500;
 
-        //let mut conn = self.pool.acquire().await?;
         let mut conn = self.pool.begin().await?;
 
         sqlx::query("

--- a/src/db/puzzle.rs
+++ b/src/db/puzzle.rs
@@ -79,45 +79,32 @@ impl PuzzleDatabase {
 
     /// Add a batch of puzzles to the database.
     pub async fn add_puzzles(&mut self, puzzles: &Vec<Puzzle>) -> DbResult<()> {
-        // Unfortunately we can only do about 2500 per query or we run out of sql variables due to
-        // the way sqlx builds the query.
-        const MAX_PER_QUERY: usize = 2500;
+        // We have to build the query ourselves to do bulk insert. I'd rather use some sort of
+        // batch insert api that lets you supply an iterator but I'm not sure how to do that with
+        // the sqlite crate. Reusing the prepared statement was about the same overhead as just
+        // creating it every time, but building the query is much faster.
+        let mut query_builder: QueryBuilder<Sqlite> = QueryBuilder::new(
+            "INSERT OR REPLACE INTO puzzles (puzzle_id, fen, moves, rating, rating_deviation,
+            popularity, number_of_plays, themes, game_url, opening_tags) "
+            );
 
-        // Create transaction.
-        let tx = self.pool.begin().await?;
+        query_builder.push_values(puzzles, |mut b, puzzle| {
+            b.push_bind(&puzzle.puzzle_id)
+                .push_bind(&puzzle.fen)
+                .push_bind(&puzzle.moves)
+                .push_bind(puzzle.rating)
+                .push_bind(puzzle.rating_deviation)
+                .push_bind(puzzle.popularity)
+                .push_bind(puzzle.number_of_plays)
+                .push_bind(puzzle.themes.join(" "))
+                .push_bind(&puzzle.game_url)
+                .push_bind(puzzle.opening_tags.join(" "));
+        });
 
-        // Import chunks of up to MAX_PER_QUERY.
-        for chunk in puzzles.chunks(MAX_PER_QUERY) {
-            // We have to build the query ourselves to do bulk insert. I'd rather use some sort of
-            // batch insert api that lets you supply an iterator but I'm not sure how to do that with
-            // the sqlite crate. Reusing the prepared statement was about the same overhead as just
-            // creating it every time, but building the query is much faster.
-            let mut query_builder: QueryBuilder<Sqlite> = QueryBuilder::new(
-                "INSERT OR REPLACE INTO puzzles (puzzle_id, fen, moves, rating, rating_deviation,
-                popularity, number_of_plays, themes, game_url, opening_tags) "
-                );
-
-            query_builder.push_values(chunk, |mut b, puzzle| {
-                b.push_bind(&puzzle.puzzle_id)
-                    .push_bind(&puzzle.fen)
-                    .push_bind(&puzzle.moves)
-                    .push_bind(puzzle.rating)
-                    .push_bind(puzzle.rating_deviation)
-                    .push_bind(puzzle.popularity)
-                    .push_bind(puzzle.number_of_plays)
-                    .push_bind(puzzle.themes.join(" "))
-                    .push_bind(&puzzle.game_url)
-                    .push_bind(puzzle.opening_tags.join(" "));
-            });
-
-            query_builder
-                .build()
-                .execute(&self.pool)
-                .await?;
-        }
-
-        // Commit the transaction.
-        tx.commit().await?;
+        query_builder
+            .build()
+            .execute(&self.pool)
+            .await?;
 
         Ok(())
     }

--- a/src/lichess.rs
+++ b/src/lichess.rs
@@ -102,7 +102,7 @@ async fn import_lichess_database(mut db: PuzzleDatabase, lichess_db_raw: File)
     /// can just update it.
     const TOTAL_PUZZLES: usize = 3_500_000;
 
-    const PUZZLES_PER_IMPORT_BATCH: usize = 100000;
+    const PUZZLES_PER_IMPORT_BATCH: usize = 10000;
     const PUZZLES_PER_PROGRESS_UPDATE: usize = 100000;
 
     // We expect 10 rows per puzzle entry.

--- a/src/lichess.rs
+++ b/src/lichess.rs
@@ -102,7 +102,7 @@ async fn import_lichess_database(mut db: PuzzleDatabase, lichess_db_raw: File)
     /// can just update it.
     const TOTAL_PUZZLES: usize = 3_500_000;
 
-    const PUZZLES_PER_IMPORT_BATCH: usize = 1000;
+    const PUZZLES_PER_IMPORT_BATCH: usize = 100000;
     const PUZZLES_PER_PROGRESS_UPDATE: usize = 100000;
 
     // We expect 10 rows per puzzle entry.

--- a/src/lichess.rs
+++ b/src/lichess.rs
@@ -1,15 +1,13 @@
 use std::fs::File;
 use std::io::{Write, SeekFrom, Seek};
-use std::sync::Arc;
 use csv::StringRecord;
 use futures::StreamExt;
-use tokio::sync::Mutex;
 
 use crate::db::{PuzzleDatabase, Puzzle};
 
 /// Initialise the puzzle db if necessary.
-pub async fn init_db(db: Arc<Mutex<PuzzleDatabase>>) -> Result<(), String> {
-    let app_data = db.lock().await.get_app_data("").await
+pub async fn init_db(db: PuzzleDatabase) -> Result<(), String> {
+    let app_data = db.get_app_data("").await
         .map_err(|e| format!("Failed to get app data: {e}"))?
         .ok_or_else(|| format!("Internal error: no app_data row in database"))?;
 
@@ -29,7 +27,7 @@ pub async fn init_db(db: Arc<Mutex<PuzzleDatabase>>) -> Result<(), String> {
             .map_err(|e| format!("Failed to import lichess puzzle db: {e}"))?;
     }
     else {
-        let puzzle_count = db.lock().await.get_puzzle_count().await
+        let puzzle_count = db.get_puzzle_count().await
             .map_err(|e| format!("Failed to get puzzle count: {e}"))?;
         log::info!("Loaded puzzle database with {puzzle_count} puzzles");
     }
@@ -95,7 +93,7 @@ async fn download_puzzle_db() -> Result<File, String> {
 }
 
 /// Import lichess database from file.
-async fn import_lichess_database(db: Arc<Mutex<PuzzleDatabase>>, lichess_db_raw: File)
+async fn import_lichess_database(mut db: PuzzleDatabase, lichess_db_raw: File)
     -> Result<(), String>
 {
     /// The total number of puzzles in the database. It's a shame to have to have this hardcoded
@@ -172,7 +170,7 @@ async fn import_lichess_database(db: Arc<Mutex<PuzzleDatabase>>, lichess_db_raw:
                     log::info!("Importing first puzzle batch...");
                 }
 
-                db.lock().await.add_puzzles(&puzzles).await
+                db.add_puzzles(&puzzles).await
                     .map_err(|e| format!("Failed to add puzzles to db: {e}"))?;
                 puzzles.clear();
             }
@@ -191,17 +189,17 @@ async fn import_lichess_database(db: Arc<Mutex<PuzzleDatabase>>, lichess_db_raw:
 
         // Add last batch (should be less than the batch size or it'll be empty).
         if !puzzles.is_empty() {
-            db.lock().await.add_puzzles(&puzzles).await
+            db.add_puzzles(&puzzles).await
                 .map_err(|e| format!("Failed to add puzzles to db: {e}"))?;
             puzzles.clear();
         }
 
         // Update flag in db to say the puzzles table is initialised.
-        let mut app_data = db.lock().await.get_app_data("").await
+        let mut app_data = db.get_app_data("").await
             .map_err(|e| format!("Failed to get app data: {e}"))?
             .ok_or_else(|| format!("No app_data row in database"))?;
         app_data.lichess_db_imported = true;
-        db.lock().await.set_app_data(&app_data).await
+        db.set_app_data(&app_data).await
             .map_err(|e| format!("Failed to update app data: {e}"))?;
 
         log::info!("Finished importing {puzzles_imported} puzzles");

--- a/src/lichess.rs
+++ b/src/lichess.rs
@@ -102,7 +102,7 @@ async fn import_lichess_database(mut db: PuzzleDatabase, lichess_db_raw: File)
     /// can just update it.
     const TOTAL_PUZZLES: usize = 3_500_000;
 
-    const PUZZLES_PER_IMPORT_BATCH: usize = 10000;
+    const PUZZLES_PER_IMPORT_BATCH: usize = 100000;
     const PUZZLES_PER_PROGRESS_UPDATE: usize = 100000;
 
     // We expect 10 rows per puzzle entry.


### PR DESCRIPTION
* Gets rid of the Arc<Mutex<_>> around PuzzleDatabase. As we use sqlx's connection pool now, PuzzleDatabase is already Clone, so the Arc/Mutex isn't needed.
* Change the puzzle batching to use a temporary table and smaller internal batches, before copying over the bigger batches from the temporary table to the main puzzles table.