### PR TITLE
Add a hint button to the puzzle ui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 [1.10.0] - ????-??-??
 
+Added:
+* A hint button that shows a hint for the next move, for if the user can't work it out, but doesn't
+  want to (or can't) go to lichess' analysis board to check the engine line. The puzzle will
+  automatically be set to failed if the hint is used, but the user can always override it on the
+  'Puzzle complete' panel and submit a positive response if desired.
+
 Fixed:
 * A small fix to the scrolwheel behavior on the puzzle board to prevent the page from scrolling
   if the mousewheel is over the board.

--- a/assets/scripts/puzzle-board.js
+++ b/assets/scripts/puzzle-board.js
@@ -13,6 +13,8 @@ export class PuzzleBoard {
         this._awaiting_promotion = false;
         this._awaiting_promotion_move = null;
 
+        this._next_move_highlight_mode = 'none';
+
         this._failed = false;
 
         this._moves = [];
@@ -119,6 +121,8 @@ export class PuzzleBoard {
         this._awaiting_promotion = false;
         this._awaiting_promotion_move = null;
 
+        this._next_move_highlight_mode = 'none';
+
         this._failed = false;
 
         this._game = this._config.fen ? new Chess(this._config.fen) : new Chess();
@@ -181,6 +185,23 @@ export class PuzzleBoard {
                 movable_color = this._player_color == 'b' ? 'black' : 'white';
             }
 
+            // Add hint shapes.
+            let hint_shapes = [];
+            let next_move = this._remaining_moves && this._remaining_moves.length > 0
+                ? this._remaining_moves[0]
+                : null;
+
+            if (next_move && this._next_move_highlight_mode != 'none') {
+                hint_shapes.push({
+                    orig: next_move.substr(0, 2),
+                    dest: this._next_move_highlight_mode != 'orig'
+                        ? next_move.substr(2)
+                        : null,
+                    brush: 'blue',
+                });
+            }
+
+            // Update board.
             this._board.set({
                 selected: null,
                 fen: board_state.fen,
@@ -198,6 +219,9 @@ export class PuzzleBoard {
                         set: (orig, dest) => { if (this.can_premove()) this._set_premove(orig, dest); },
                         unset: (orig, dest) => { if (this.can_premove()) this._unset_premove(orig, dest); },
                     }
+                },
+                drawable: {
+                    autoShapes: hint_shapes,
                 },
             });
         }
@@ -481,5 +505,19 @@ export class PuzzleBoard {
 
         if (this._config.on_seek)
             this._config.on_seek();
+    }
+
+    // Highlight the next move. Options for `mode` are:
+    // * 'move' - an arrow showing the move
+    // * 'orig' - highlight the piece to move
+    // * 'none' - do not highlight the next move (default)
+    set_next_move_highlight(mode) {
+        this._next_move_highlight_mode = mode;
+        this.sync_board();
+    }
+
+    // Returns the current next move highlight mode.
+    get_next_move_highlight() {
+        return this._next_move_highlight_mode;
     }
 }

--- a/assets/scripts/puzzle-ui.js
+++ b/assets/scripts/puzzle-ui.js
@@ -563,13 +563,16 @@ export class PuzzleUi {
     wrong_move() {
         if (this.puzzle.is_failed()) {
             return h('div#wrong-move.bt-panel.controls-subpanel', [
-                h('b', 'Wrong move'),
+                h('p', 'Wrong move'),
                 h('div.columns.button-container', [
                     h('div.column'),
                     h('div.column', [
                         h('button#try-again.button',
                             { on: { click: () => { this.puzzle.reset(); this.render(); } } },
-                            h('p.main-text', 'Try again')
+                            [
+                                h('p.main-text', 'Reset'),
+                                h('p.sub-text', 'Try again'),
+                            ],
                         ),
                     ]),
                     h('div.column'),
@@ -585,7 +588,7 @@ export class PuzzleUi {
             if (this.first_try) {
                 let card = this.config.card;
                 return h('div#reviewing-ahead.bt-panel.controls-subpanel', [
-                    h('b', 'Puzzle complete'),
+                    h('p', 'Puzzle complete'),
                     h('div.columns.button-container', [
                         h('div.column', [
                             h('button#hard.button.review-button', {
@@ -634,10 +637,7 @@ export class PuzzleUi {
             else {
                 let card = this.config.card;
                 return h('div#reviewing-ahead.bt-panel.controls-subpanel', [
-                    h('p', [
-                        h('b', 'Puzzle complete'),
-                        ' (with mistakes)',
-                    ]),
+                    h('p', 'Puzzle complete (with mistakes)'),
                     h('div.columns.button-container', [
                         h('div.column'),
                         h('div.column', [
@@ -679,10 +679,12 @@ export class PuzzleUi {
             else
                 button_text = 'Show hint';
 
+            let disable_button = this.puzzle.computer_to_move() || this.puzzle.awaiting_promotion();
+
             return h('div#hint-button.bt-panel.controls-subpanel', [
                 h('a.puzzle-link-button', {
                     on: { click: this.on_hint_button_clicked.bind(this) },
-                    attrs: { disabled: this.puzzle.computer_to_move() },
+                    attrs: { disabled: disable_button },
                 }, button_text),
             ]);
         }

--- a/assets/scripts/puzzle-ui.js
+++ b/assets/scripts/puzzle-ui.js
@@ -36,17 +36,27 @@ export class PuzzleUi {
 
         // Render once and create the puzzle board.
         this.render();
+        
         this.puzzle = new PuzzleBoard(document.getElementById("board"), {
-            on_success: this.render.bind(this),
-            on_move: this.render.bind(this),
-            on_right_move: this.render.bind(this),
-            on_wrong_move: () => { this.first_try = false; this.render(); },
+            on_success: this.on_puzzle_board_change.bind(this),
+            on_move: this.on_puzzle_board_change.bind(this),
+            on_right_move: this.on_puzzle_board_change.bind(this),
+            on_wrong_move: () => { this.first_try = false; this.on_puzzle_board_change(); },
+            on_seek: this.on_puzzle_board_change.bind(this),
             on_promote: this.render.bind(this),
-            on_seek: this.render.bind(this),
         });
 
         this.configure(config ? config : {});
         this.request_data();
+    }
+
+    on_puzzle_board_change() {
+        // If something on the puzzle changes due to user input (e.g. a new move or seeking),
+        // disable the next move hint.
+        this.puzzle.set_next_move_highlight('none');
+
+        // Re-render the ui to reflect the updated puzzle state.
+        this.render();
     }
 
     configure(config) {
@@ -267,15 +277,15 @@ export class PuzzleUi {
                 this.puzzle_info(),
                 this.card_stats(),
                 this.side_to_move(),
-                this.find_the_line(),
                 this.wrong_move(),
-                this.right_move(),
+                this.hint_button(),
                 this.puzzle_complete(),
-                this.puzzle_themes(),
                 this.reviewing_ahead(),
                 this.skip_button(),
                 this.dont_repeat_button(),
+                this.too_easy_button(),
                 this.too_hard_button(),
+                this.puzzle_themes(),
             ]);
         }
     }
@@ -506,14 +516,6 @@ export class PuzzleUi {
         }
     }
 
-    find_the_line() {
-        if (this.puzzle.is_first_move()) {
-            return h('div#find-the-line.bt-panel.controls-subpanel', [
-                h('p', 'Find the line!'),
-            ]);
-        }
-    }
-
     skip_button() {
         if (this.config.mode == 'Random' && this.puzzle && this.puzzle.is_first_move()) {
             return h('div#skip-button.bt-panel.controls-subpanel', [
@@ -537,6 +539,14 @@ export class PuzzleUi {
         if (this.config.mode == 'Random' && is_success) {
             return h('div#dont-repeat.bt-panel.controls-subpanel', [
                 h('a', { on: { click: this.on_dont_repeat_clicked.bind(this) } }, "Don't repeat this puzzle"),
+            ]);
+        }
+    }
+
+    too_easy_button() {
+        let is_success = this.puzzle.is_complete() && this.first_try;
+        if (this.config.mode == 'Random' && is_success) {
+            return h('div#too-easy.bt-panel.controls-subpanel', [
                 h('a', { on: { click: this.on_too_easy_clicked.bind(this) } }, "Too easy (see harder puzzles)"),
             ]);
         }
@@ -553,27 +563,18 @@ export class PuzzleUi {
     wrong_move() {
         if (this.puzzle.is_failed()) {
             return h('div#wrong-move.bt-panel.controls-subpanel', [
-                h('p', 'Wrong move :('),
+                h('b', 'Wrong move'),
                 h('div.columns.button-container', [
                     h('div.column'),
                     h('div.column', [
                         h('button#try-again.button',
                             { on: { click: () => { this.puzzle.reset(); this.render(); } } },
-                            h('p.main-text', "Reset")
+                            h('p.main-text', 'Try again')
                         ),
                     ]),
                     h('div.column'),
                 ]),
             ]);
-        }
-    }
-
-    right_move() {
-        if (this.puzzle.is_puzzle_loaded() && !this.puzzle.is_first_move() &&
-            !this.puzzle.is_failed() && !this.puzzle.is_complete())
-        {
-            return h('div#right-move.bt-panel.controls-subpanel',
-                "Right move!");
         }
     }
 
@@ -584,7 +585,7 @@ export class PuzzleUi {
             if (this.first_try) {
                 let card = this.config.card;
                 return h('div#reviewing-ahead.bt-panel.controls-subpanel', [
-                    h('p', 'Puzzle complete'),
+                    h('b', 'Puzzle complete'),
                     h('div.columns.button-container', [
                         h('div.column', [
                             h('button#hard.button.review-button', {
@@ -633,7 +634,10 @@ export class PuzzleUi {
             else {
                 let card = this.config.card;
                 return h('div#reviewing-ahead.bt-panel.controls-subpanel', [
-                    h('p', 'Puzzle complete (with mistakes)'),
+                    h('p', [
+                        h('b', 'Puzzle complete'),
+                        ' (with mistakes)',
+                    ]),
                     h('div.columns.button-container', [
                         h('div.column'),
                         h('div.column', [
@@ -652,7 +656,7 @@ export class PuzzleUi {
                         h('div.column'),
                     ]),
                     h('p', [
-                        h('a#override-link',
+                        h('a.puzzle-link-button',
                             { on: { click: () => { this.first_try = true; this.render(); } } },
                             'Submit positive answer anyway'
                         ),
@@ -661,6 +665,48 @@ export class PuzzleUi {
                 ]);
             }
         }
+    }
+
+    hint_button() {
+        if (this.puzzle && !this.puzzle.is_complete() && !this.puzzle.is_failed()) {
+            let button_text;
+
+            let mode = this.puzzle.get_next_move_highlight();
+            if (mode == 'move')
+                button_text = 'Hide hint';
+            else if (mode == 'orig')
+                button_text = 'Show hint (move)';
+            else
+                button_text = 'Show hint';
+
+            return h('div#hint-button.bt-panel.controls-subpanel', [
+                h('a.puzzle-link-button', {
+                    on: { click: this.on_hint_button_clicked.bind(this) },
+                    attrs: { disabled: this.puzzle.computer_to_move() },
+                }, button_text),
+            ]);
+        }
+    }
+
+    on_hint_button_clicked() {
+        // Set first_try to false to show the 'again' button by default if the user needed a hint.
+        this.first_try = false;
+
+        // If the move is already highlighted, disable the highlight.
+        let cur = this.puzzle.get_next_move_highlight();
+        if (cur == 'move') {
+            this.puzzle.set_next_move_highlight('none');
+        }
+        // If the piece to move is already highlighted, show the move itself.
+        else if (cur == 'orig') {
+            this.puzzle.set_next_move_highlight('move');
+        }
+        // If the mode is 'none', start by highlighting the piece.
+        else {
+            this.puzzle.set_next_move_highlight('orig');
+        }
+
+        this.render();
     }
 
     on_promotion_button_clicked(event) {

--- a/assets/style.css
+++ b/assets/style.css
@@ -470,11 +470,6 @@ cg-board {
     flex-basis: 100%;
 }
 
-#dont-repeat a {
-    display: block;
-    margin-bottom: 0.5rem;
-}
-
 .sidebar .bt-panel {
     text-align: center;
 }
@@ -504,15 +499,8 @@ cg-board {
     font-size: 0.8em;
 }
 
-#override-link {
+a.puzzle-link-button {
     user-select: none;
-}
-
-/* Never show these on mobile, it's a bit of a waste of space */
-@media only screen and (max-width: 768px) {
-    #find-the-line, #right-move {
-        display: none !important;
-    }
 }
 
 /* About page - these might apply to other pages too, but I thought I'd try them here first */
@@ -617,7 +605,7 @@ cg-board {
     user-select: none;
 }
 
-.pagination a[disabled] {
+a[disabled] {
     font-weight: unset;
     cursor: unset;
     color: grey !important;


### PR DESCRIPTION
A hint button that shows a hint for the next move, for if the user can't work it out, but doesn't want to (or can't) go to lichess' analysis board to check the engine line. The puzzle will automatically be set to failed if the hint is used, but the user can always override it on the 'Puzzle complete' panel and submit a positive response if desired.

Also removes the 'find the line' and 'right move' panels from the sidebar, they were hidden on mobile anyway and take up an unnecessary amount of space for something useless.

closes #33 